### PR TITLE
Apply a set of rules to help with JDK8 upgrade

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -197,6 +197,7 @@
         <configuration>
           <environmentVariables>
             <GH_TOKEN>fake-token</GH_TOKEN>
+            <GH_OWNER>fake-owner</GH_OWNER>
             <GH_TARGET_ORGANISATION>jenkinsci</GH_TARGET_ORGANISATION>
           </environmentVariables>
         </configuration>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/GuiceModule.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/GuiceModule.java
@@ -6,6 +6,7 @@ import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
 import io.jenkins.tools.pluginmodernizer.core.utils.JdkFetcher;
+import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterService;
 import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.Invoker;
 
@@ -21,8 +22,9 @@ public class GuiceModule extends AbstractModule {
     protected void configure() {
         bind(Invoker.class).to(DefaultInvoker.class);
         bind(Config.class).toInstance(config);
-        bind(GHService.class).toInstance(new GHService());
         bind(CacheManager.class).toInstance(new CacheManager(config.getCachePath()));
+        bind(UpdateCenterService.class).toInstance(new UpdateCenterService());
+        bind(GHService.class).toInstance(new GHService());
         bind(JdkFetcher.class).toInstance(new JdkFetcher(config.getCachePath()));
         bind(PluginModernizer.class).toInstance(new PluginModernizer());
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -14,6 +14,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
 import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.YamlResourceLoader;
 import org.slf4j.Logger;
@@ -50,6 +51,14 @@ public class Settings {
     public static final String ADOPTIUM_GITHUB_API_URL = "https://api.github.com/repos/adoptium";
 
     public static final ComparableVersion MAVEN_MINIMAL_VERSION = new ComparableVersion("3.9.7");
+
+    public static final String REMEDIATION_JENKINS_MINIMUM_VERSION;
+
+    public static final String REMEDIATION_PLUGIN_PARENT_VERSION;
+
+    public static final String REMEDIATION_BOM_BASE;
+
+    public static final String REMEDIATION_BOM_VERSION;
 
     public static final List<Recipe> AVAILABLE_RECIPES;
 
@@ -91,6 +100,11 @@ public class Settings {
         } catch (MalformedURLException e) {
             throw new ModernizerException("Invalid URL format", e);
         }
+
+        REMEDIATION_JENKINS_MINIMUM_VERSION = getRemediationJenkinsMinimumVersion();
+        REMEDIATION_BOM_BASE = getRemediationBomBase();
+        REMEDIATION_BOM_VERSION = getRemediationBomVersion();
+        REMEDIATION_PLUGIN_PARENT_VERSION = getRemediationPluginParentVersion();
 
         // Get recipes module
         try (InputStream inputStream = Settings.class.getResourceAsStream("/" + Settings.RECIPE_DATA_YAML_PATH)) {
@@ -144,6 +158,22 @@ public class Settings {
             return new URL(url);
         }
         return new URL(readProperty("plugin.versions.url", "urls.properties"));
+    }
+
+    private static @NotNull String getRemediationJenkinsMinimumVersion() {
+        return readProperty("remediation.jenkins.minimum.version", "versions.properties");
+    }
+
+    private static @NotNull String getRemediationPluginParentVersion() {
+        return readProperty("remediation.jenkins.plugin.parent.version", "versions.properties");
+    }
+
+    private static @NotNull String getRemediationBomBase() {
+        return readProperty("remediation.bom.base", "versions.properties");
+    }
+
+    private static @NotNull String getRemediationBomVersion() {
+        return readProperty("remediation.bom.version", "versions.properties");
     }
 
     private static @Nullable URL getHealthScoreUrl() throws MalformedURLException {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFlag.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFlag.java
@@ -1,8 +1,13 @@
 package io.jenkins.tools.pluginmodernizer.core.extractor;
 
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterService;
 import java.util.Optional;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Flag for metadata
@@ -12,69 +17,94 @@ public enum MetadataFlag {
     /**
      * If the SCM URL uses HTTPS
      */
-    SCM_HTTPS(tag -> {
-        if ("scm".equals(tag.getName())) {
-            Optional<String> connection = tag.getChildValue("connection");
-            return connection.isPresent() && connection.get().startsWith("scm:git:https");
-        }
-        return false;
-    }),
+    SCM_HTTPS(
+            tag -> {
+                if ("scm".equals(tag.getName())) {
+                    Optional<String> connection = tag.getChildValue("connection");
+                    return connection.isPresent() && connection.get().startsWith("scm:git:https");
+                }
+                return false;
+            },
+            null),
 
     /**
      * If the plugin uses HTTPS for all its repositories
      */
-    MAVEN_REPOSITORIES_HTTPS(tag -> {
-        if ("repositories".equals(tag.getName())) {
-            return tag.getChildren().stream()
-                    .filter(c -> "repository".equals(c.getName()))
-                    .map(Xml.Tag.class::cast)
-                    .map(r -> r.getChildValue("url").orElseThrow())
-                    .allMatch(url -> url.startsWith("https"));
-        }
-        return false;
-    }),
+    MAVEN_REPOSITORIES_HTTPS(
+            tag -> {
+                if ("repositories".equals(tag.getName())) {
+                    return tag.getChildren().stream()
+                            .filter(c -> "repository".equals(c.getName()))
+                            .map(Xml.Tag.class::cast)
+                            .map(r -> r.getChildValue("url").orElseThrow())
+                            .allMatch(url -> url.startsWith("https"));
+                }
+                return false;
+            },
+            null),
 
     /**
      * If the license block is set
      */
-    LICENSE_SET(tag -> {
-        if ("licenses".equals(tag.getName())) {
-            return tag.getChildren().stream()
-                    .filter(c -> "license".equals(c.getName()))
-                    .map(Xml.Tag.class::cast)
-                    .map(r -> r.getChildValue("name").orElseThrow())
-                    .findAny()
-                    .isPresent();
-        }
-        return false;
-    }),
+    LICENSE_SET(
+            tag -> {
+                if ("licenses".equals(tag.getName())) {
+                    return tag.getChildren().stream()
+                            .filter(c -> "license".equals(c.getName()))
+                            .map(Xml.Tag.class::cast)
+                            .map(r -> r.getChildValue("name").orElseThrow())
+                            .findAny()
+                            .isPresent();
+                }
+                return false;
+            },
+            null),
 
     /**
      * If the develop block is set
      */
-    DEVELOPER_SET(tag -> {
-        if ("developers".equals(tag.getName())) {
-            return tag.getChildren().stream()
-                    .filter(c -> "developer".equals(c.getName()))
-                    .map(Xml.Tag.class::cast)
-                    .map(r -> r.getChildValue("id").orElseThrow())
-                    .findAny()
-                    .isPresent();
-        }
-        return false;
-    });
+    DEVELOPER_SET(
+            tag -> {
+                if ("developers".equals(tag.getName())) {
+                    return tag.getChildren().stream()
+                            .filter(c -> "developer".equals(c.getName()))
+                            .map(Xml.Tag.class::cast)
+                            .map(r -> r.getChildValue("id").orElseThrow())
+                            .findAny()
+                            .isPresent();
+                }
+                return false;
+            },
+            null),
+
+    /**
+     * If the plugin is an API plugin
+     */
+    IS_API_PLUGIN(null, (plugin, updateCenterService) -> updateCenterService.isApiPlugin(plugin)),
+
+    /**
+     * If the plugin is deprecated
+     */
+    IS_DEPRECATED(null, (plugin, updateCenterService) -> updateCenterService.isDeprecated(plugin)),
+    ;
 
     /**
      * Function to check if the flag is applicable for the given XML tag
      */
-    private final Predicate<Xml.Tag> isApplicable;
+    private final Predicate<Xml.Tag> isApplicableTag;
+
+    /**
+     * Function to check if the flag is applicable for the given plugin
+     */
+    private final BiPredicate<Plugin, UpdateCenterService> isApplicablePlugin;
 
     /**
      * Constructor
-     * @param isApplicable Predicate to check if the flag is applicable for the given XML tag
+     * @param isApplicableTag Predicate to check if the flag is applicable for the given XML tag
      */
-    MetadataFlag(Predicate<Xml.Tag> isApplicable) {
-        this.isApplicable = isApplicable;
+    MetadataFlag(Predicate<Xml.Tag> isApplicableTag, BiPredicate<Plugin, UpdateCenterService> isApplicablePlugin) {
+        this.isApplicableTag = isApplicableTag;
+        this.isApplicablePlugin = isApplicablePlugin;
     }
 
     /**
@@ -83,6 +113,34 @@ public enum MetadataFlag {
      * @return true if the flag is applicable
      */
     public boolean isApplicable(Xml.Tag tag) {
-        return isApplicable.test(tag);
+        if (isApplicableTag == null) {
+            return false;
+        }
+        return isApplicableTag.test(tag);
     }
+
+    /**
+     * Check if the flag is applicable for the given plugin
+     * @param plugin Plugin
+     * @return true if the flag is applicable
+     */
+    public boolean isApplicable(Plugin plugin, UpdateCenterService updateCenterService) {
+        if (plugin.getMetadata() == null) {
+            LOG.debug("Metadata not found for plugin {}", plugin.getName());
+            return false;
+        }
+        if (plugin.getMetadata().hasFlag(this)) {
+            LOG.debug("Flag {} already set for plugin {}", this, plugin.getName());
+            return true;
+        }
+        if (isApplicablePlugin == null) {
+            LOG.debug("No applicable plugin check for flag {}", this);
+            return false;
+        }
+        boolean result = isApplicablePlugin.test(plugin, updateCenterService);
+        LOG.debug("Flag {} applicable for plugin {}: {}", this, plugin.getName(), result);
+        return result;
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetadataFlag.class);
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -8,6 +8,7 @@ import io.jenkins.tools.pluginmodernizer.core.model.PreconditionError;
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -112,11 +113,21 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serial
         this.flags = flags;
     }
 
+    public void addFlag(MetadataFlag flag) {
+        if (flags == null) {
+            flags = new HashSet<>();
+        }
+        flags.add(flag);
+    }
+
     public boolean hasFlag(MetadataFlag flag) {
-        return flags.contains(flag);
+        return flags != null && flags.contains(flag);
     }
 
     public Set<PreconditionError> getErrors() {
+        if (errors == null) {
+            errors = new HashSet<>();
+        }
         return Collections.unmodifiableSet(errors);
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -160,6 +160,18 @@ public class CacheManager {
     }
 
     /**
+     * Copy a cache entry to the new cache manager
+     * @param cacheManager The cache manager
+     * @param newPath The new path
+     * @param newKey The new key
+     * @param entry The cache entry to move
+     */
+    public <T extends CacheEntry<T>> T copy(
+            CacheManager cacheManager, Path newPath, String newKey, CacheEntry<T> entry) {
+        return entry.copy(cacheManager, newPath, newKey);
+    }
+
+    /**
      * Get the location of the cache
      * @return The location
      */

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -133,6 +133,7 @@ public class PluginModernizer {
                 }
             }
 
+            mavenInvoker.ensureMinimalBuild(plugin);
             plugin.checkoutBranch(ghService);
 
             // Minimum JDK to run openrewrite

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -10,7 +10,7 @@ import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
 import io.jenkins.tools.pluginmodernizer.core.utils.HealthScoreUtils;
 import io.jenkins.tools.pluginmodernizer.core.utils.PluginVersionUtils;
-import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterUtils;
+import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterService;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +31,9 @@ public class PluginModernizer {
 
     @Inject
     private GHService ghService;
+
+    @Inject
+    private UpdateCenterService updateCenterService;
 
     @Inject
     private CacheManager cacheManager;
@@ -84,18 +87,15 @@ public class PluginModernizer {
             plugin.withConfig(config);
 
             // Determine repo name
-            plugin.withRepositoryName(UpdateCenterUtils.extractRepoName(plugin, cacheManager));
+            plugin.withRepositoryName(updateCenterService.extractRepoName(plugin));
 
-            LOG.debug(
-                    "Plugin {} latest version: {}",
-                    plugin.getName(),
-                    UpdateCenterUtils.extractVersion(plugin, cacheManager));
+            LOG.debug("Plugin {} latest version: {}", plugin.getName(), updateCenterService.extractVersion(plugin));
             LOG.debug(
                     "Plugin {} health score: {}",
                     plugin.getName(),
                     HealthScoreUtils.extractScore(plugin, cacheManager));
-            LOG.debug("Is API plugin {} : {}", plugin.getName(), plugin.isApiPlugin(cacheManager));
-            if (plugin.isDeprecated(cacheManager)) {
+            LOG.debug("Is API plugin {} : {}", plugin.getName(), plugin.isApiPlugin(updateCenterService));
+            if (plugin.isDeprecated(updateCenterService)) {
                 LOG.info("Plugin {} is deprecated. Skipping.", plugin.getName());
                 plugin.addError("Plugin is deprecated");
                 return;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
@@ -95,6 +95,19 @@ public abstract class CacheEntry<T extends CacheEntry<T>> implements Serializabl
      * @return The refreshed object copied
      */
     public final T move(CacheManager newCacheManager, Path newPath, String newKey) {
+        return move(newCacheManager, newPath, newKey, false);
+    }
+
+    /**
+     * Return a copy of this object copied to another cache manager
+     * @param newCacheManager The new cache manager
+     * @return The refreshed object copied
+     */
+    public final T copy(CacheManager newCacheManager, Path newPath, String newKey) {
+        return move(newCacheManager, newPath, newKey, true);
+    }
+
+    private T move(CacheManager newCacheManager, Path newPath, String newKey, boolean copy) {
         LOG.debug(
                 "Moving object from {} to {}",
                 cacheManager.getLocation().resolve(path).resolve(key),
@@ -106,7 +119,9 @@ public abstract class CacheEntry<T extends CacheEntry<T>> implements Serializabl
         refreshedObject.setCacheManager(newCacheManager);
         newCacheManager.put(refreshedObject);
         LOG.debug(refreshedObject.getCacheManager().getLocation().toString());
-        this.delete();
+        if (!copy) {
+            this.delete();
+        }
         return newCacheManager.get(newPath, newKey, clazz);
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -6,7 +6,7 @@ import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
 import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
-import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterUtils;
+import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterService;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -580,20 +580,18 @@ public class Plugin {
 
     /**
      * Return if this plugin is deprecated in the update center
-     * @param cacheManager The cache manager
      * @return True if the plugin is deprecated
      */
-    public boolean isDeprecated(CacheManager cacheManager) {
-        return UpdateCenterUtils.isDeprecated(this, cacheManager);
+    public boolean isDeprecated(UpdateCenterService updateCenterService) {
+        return updateCenterService.isDeprecated(this);
     }
 
     /**
      * Return if this plugin is an API plugin
-     * @param cacheManager The cache manager
      * @return True if the plugin is an API plugin
      */
-    public boolean isApiPlugin(CacheManager cacheManager) {
-        return UpdateCenterUtils.isApiPlugin(this, cacheManager);
+    public boolean isApiPlugin(UpdateCenterService updateCenterService) {
+        return updateCenterService.isApiPlugin(this);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -69,9 +69,6 @@ public enum PreconditionError {
                 }
             },
             plugin -> {
-                // TODO: Implement remediation function (See
-                // https://github.com/jenkinsci/plugin-modernizer-tool/pull/307)
-
                 PomModifier pomModifier = new PomModifier(
                         plugin.getLocalRepository().resolve("pom.xml").toString());
                 pomModifier.removeOffendingProperties();

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -86,7 +86,7 @@ public enum PreconditionError {
                 pomModifier.savePom(
                         plugin.getLocalRepository().resolve("pom.xml").toString());
                 plugin.withoutErrors();
-                return false;
+                return true;
             },
             "Found older Java version in pom file preventing using recent Maven older than 3.9.x"),
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -20,9 +20,7 @@ public enum PreconditionError {
      * No pom file found
      */
     NO_POM(
-            (document, xpath) -> {
-                return document == null;
-            },
+            (document, xpath) -> document == null,
             plugin -> false, // No remediation function available if pom is missing
             "No pom file found"),
 
@@ -85,6 +83,7 @@ public enum PreconditionError {
 
                 pomModifier.savePom(
                         plugin.getLocalRepository().resolve("pom.xml").toString());
+                // new CacheManager(config.getCachePath())
                 plugin.withoutErrors();
                 return true;
             },

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -168,6 +168,56 @@ public class PomModifier {
     }
 
     /**
+     * Adds a BOM section to the POM file.
+     *
+     * @param groupId the groupId of the BOM
+     * @param artifactId the artifactId of the BOM
+     * @param version the version of the BOM
+     */
+    public void addBom(String groupId, String artifactId, String version) {
+        NodeList dependencyManagementList = document.getElementsByTagName("dependencyManagement");
+        Element dependencyManagementElement;
+
+        if (dependencyManagementList.getLength() > 0) {
+            dependencyManagementElement = (Element) dependencyManagementList.item(0);
+        } else {
+            dependencyManagementElement = document.createElement("dependencyManagement");
+            document.getDocumentElement().appendChild(dependencyManagementElement);
+        }
+
+        Element dependenciesElement = (Element)
+                dependencyManagementElement.getElementsByTagName("dependencies").item(0);
+        if (dependenciesElement == null) {
+            dependenciesElement = document.createElement("dependencies");
+            dependencyManagementElement.appendChild(dependenciesElement);
+        }
+
+        Element dependencyElement = document.createElement("dependency");
+
+        Element groupIdElement = document.createElement("groupId");
+        groupIdElement.appendChild(document.createTextNode(groupId));
+        dependencyElement.appendChild(groupIdElement);
+
+        Element artifactIdElement = document.createElement("artifactId");
+        artifactIdElement.appendChild(document.createTextNode(artifactId));
+        dependencyElement.appendChild(artifactIdElement);
+
+        Element versionElement = document.createElement("version");
+        versionElement.appendChild(document.createTextNode(version));
+        dependencyElement.appendChild(versionElement);
+
+        Element typeElement = document.createElement("type");
+        typeElement.appendChild(document.createTextNode("pom"));
+        dependencyElement.appendChild(typeElement);
+
+        Element scopeElement = document.createElement("scope");
+        scopeElement.appendChild(document.createTextNode("import"));
+        dependencyElement.appendChild(scopeElement);
+
+        dependenciesElement.appendChild(dependencyElement);
+    }
+
+    /**
      * Saves the modified POM file to the specified output path.
      *
      * @param outputPath the path to save the POM file

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -1,0 +1,197 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Utility class for modifying POM files.
+ */
+public class PomModifier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PomModifier.class);
+    private Document document;
+
+    // Base directory for file operations
+    private static final String BASE_DIR = System.getProperty("java.io.tmpdir");
+
+    /**
+     * Constructor for PomModifier.
+     *
+     * @param pomFilePath the path to the POM file
+     * @throws IllegalArgumentException if the file path is invalid
+     */
+    @SuppressFBWarnings("PATH_TRAVERSAL_IN")
+    public PomModifier(String pomFilePath) {
+        try {
+            // Validate the file path
+            Path path = Paths.get(pomFilePath).normalize().toAbsolutePath();
+            if (!Files.exists(path) || !Files.isRegularFile(path)) {
+                throw new IllegalArgumentException("Invalid file path: " + path.toString());
+            }
+
+            File pomFile = path.toFile();
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbFactory.setXIncludeAware(false);
+            dbFactory.setExpandEntityReferences(false);
+            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            document = dBuilder.parse(pomFile);
+            document.getDocumentElement().normalize();
+        } catch (InvalidPathException e) {
+            LOG.error("Invalid file path: " + e.getMessage());
+            throw new IllegalArgumentException("Invalid file path: " + pomFilePath, e);
+        } catch (IllegalArgumentException e) {
+            LOG.error("Invalid file path: " + e.getMessage());
+            throw e; // Re-throw to ensure the caller is aware of the issue
+        } catch (Exception e) {
+            LOG.error("Error initializing PomModifier: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to initialize PomModifier", e); // Re-throw as a runtime exception
+        }
+    }
+
+    /**
+     * Removes offending properties from the POM file.
+     */
+    public void removeOffendingProperties() {
+        NodeList propertiesList = document.getElementsByTagName("properties");
+        if (propertiesList.getLength() > 0) {
+            Node propertiesNode = propertiesList.item(0);
+            NodeList childNodes = propertiesNode.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node node = childNodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE) {
+                    String nodeName = node.getNodeName();
+                    if (nodeName.equals("jenkins-test-harness.version") || nodeName.equals("java.level")) {
+                        propertiesNode.removeChild(node);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Updates the parent POM information.
+     *
+     * @param groupId the groupId to set
+     * @param artifactId the artifactId to set
+     * @param version the version to set
+     */
+    public void updateParentPom(String groupId, String artifactId, String version) {
+        NodeList parentList = document.getElementsByTagName("parent");
+        if (parentList.getLength() > 0) {
+            Node parentNode = parentList.item(0);
+            NodeList childNodes = parentNode.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node node = childNodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE) {
+                    switch (node.getNodeName()) {
+                        case "groupId":
+                            node.setTextContent(groupId);
+                            break;
+                        case "artifactId":
+                            node.setTextContent(artifactId);
+                            break;
+                        case "version":
+                            node.setTextContent(version);
+                            break;
+                        default:
+                            LOG.warn("Unexpected element in parent POM: " + node.getNodeName());
+                            break;
+                    }
+                }
+            }
+        } else {
+            Element parentElement = document.createElement("parent");
+
+            Element groupIdElement = document.createElement("groupId");
+            groupIdElement.appendChild(document.createTextNode(groupId));
+            parentElement.appendChild(groupIdElement);
+
+            Element artifactIdElement = document.createElement("artifactId");
+            artifactIdElement.appendChild(document.createTextNode(artifactId));
+            parentElement.appendChild(artifactIdElement);
+
+            Element versionElement = document.createElement("version");
+            versionElement.appendChild(document.createTextNode(version));
+            parentElement.appendChild(versionElement);
+
+            document.getDocumentElement().appendChild(parentElement);
+        }
+    }
+
+    /**
+     * Updates the Jenkins minimal version in the POM file.
+     *
+     * @param version the version to set
+     */
+    public void updateJenkinsMinimalVersion(String version) {
+        NodeList propertiesList = document.getElementsByTagName("properties");
+        if (propertiesList.getLength() > 0) {
+            Node propertiesNode = propertiesList.item(0);
+            NodeList childNodes = propertiesNode.getChildNodes();
+            boolean versionUpdated = false;
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node node = childNodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE
+                        && node.getNodeName().equals("jenkins.version")) {
+                    node.setTextContent(version);
+                    versionUpdated = true;
+                    break;
+                }
+            }
+            if (!versionUpdated) {
+                Element jenkinsVersionElement = document.createElement("jenkins.version");
+                jenkinsVersionElement.appendChild(document.createTextNode(version));
+                propertiesNode.appendChild(jenkinsVersionElement);
+            }
+        }
+    }
+
+    /**
+     * Saves the modified POM file to the specified output path.
+     *
+     * @param outputPath the path to save the POM file
+     * @throws IllegalArgumentException if the output path is invalid
+     */
+    @SuppressFBWarnings("PATH_TRAVERSAL_IN")
+    public void savePom(String outputPath) {
+        try {
+            // Validate the output path
+            Path path = Paths.get(outputPath).normalize().toAbsolutePath();
+
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            DOMSource source = new DOMSource(document);
+            StreamResult result = new StreamResult(new File(outputPath));
+            transformer.transform(source, result);
+        } catch (InvalidPathException e) {
+            LOG.error("Invalid output path: " + e.getMessage());
+            throw new IllegalArgumentException("Invalid output path: " + outputPath, e);
+        } catch (Exception e) {
+            LOG.error("Error saving POM file: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to save POM file", e);
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/UpdateCenterService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/UpdateCenterService.java
@@ -66,6 +66,11 @@ public class UpdateCenterService {
                 && updateCenterPlugin.labels().contains("deprecated");
     }
 
+    /**
+     * Check if a plugin is an API plugin
+     * @param plugin Plugin
+     * @return True if API plugin
+     */
     public boolean isApiPlugin(Plugin plugin) {
         UpdateCenterData updateCenterData = get();
         UpdateCenterData.UpdateCenterPlugin updateCenterPlugin =

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -1,5 +1,5 @@
 openrewrite.maven.plugin.version = ${openrewrite.maven.plugin.version}
-jenkins.minimum.version = 2.440.3
-jenkins.plugin.parent.version = 4.80
-bom.version = 3413.v0d896b_76a_30d
-bom.base = bom-2.440.x
+remediation.jenkins.minimum.version = 2.440.3
+remediation.jenkins.plugin.parent.version = 4.51
+remediation.bom.version = 3413.v0d896b_76a_30d
+remediation.bom.base = bom-2.440.x

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -1,0 +1,110 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import static java.nio.file.Files.createTempFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.logging.Logger;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class PomModifierTest {
+    private static final Logger logger = Logger.getLogger(PomModifierTest.class.getName());
+
+    private static final String TEST_POM_PATH = "src/test/resources/test-pom.xml";
+    private static final String OUTPUT_POM_PATH;
+
+    static {
+        try {
+            OUTPUT_POM_PATH = Files.move(
+                            createTempFile(null, null),
+                            Paths.get(System.getProperty("java.io.tmpdir"), "output-pom.xml"),
+                            StandardCopyOption.REPLACE_EXISTING)
+                    .toAbsolutePath()
+                    .toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Path tempFile = new File(OUTPUT_POM_PATH).toPath();
+        Files.copy(Path.of(TEST_POM_PATH), tempFile, StandardCopyOption.REPLACE_EXISTING);
+        logger.info("Setup completed, copied test POM to temporary file: " + tempFile.toString());
+    }
+
+    @Test
+    public void testRemoveOffendingProperties() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.removeOffendingProperties();
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        Element propertiesElement =
+                (Element) doc.getElementsByTagName("properties").item(0);
+        assertTrue(propertiesElement.getElementsByTagName("java.level").getLength() == 0);
+        assertTrue(propertiesElement
+                        .getElementsByTagName("jenkins-test-harness.version")
+                        .getLength()
+                == 0);
+        logger.info("Offending properties removed successfully");
+    }
+
+    @Test
+    public void testUpdateParentPom() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.updateParentPom("org.jenkins-ci.plugins", "plugin", "4.80");
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        Element parentElement = (Element) doc.getElementsByTagName("parent").item(0);
+        assertEquals(
+                "org.jenkins-ci.plugins",
+                parentElement.getElementsByTagName("groupId").item(0).getTextContent());
+        assertEquals(
+                "plugin",
+                parentElement.getElementsByTagName("artifactId").item(0).getTextContent());
+        assertEquals(
+                "4.80", parentElement.getElementsByTagName("version").item(0).getTextContent());
+    }
+
+    @Test
+    public void testUpdateJenkinsMinimalVersion() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.updateJenkinsMinimalVersion("2.462.2");
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        Element propertiesElement =
+                (Element) doc.getElementsByTagName("properties").item(0);
+        String jenkinsVersion = propertiesElement
+                .getElementsByTagName("jenkins.version")
+                .item(0)
+                .getTextContent();
+        logger.info("Jenkins version found: " + jenkinsVersion);
+        assertEquals("2.462.2", jenkinsVersion);
+    }
+}

--- a/plugin-modernizer-core/src/test/resources/test-pom.xml
+++ b/plugin-modernizer-core/src/test/resources/test-pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>1.554.1</version>
+    <relativePath />
+  </parent>
+
+  <properties>
+    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+    <jenkins.version>1.532.3</jenkins.version>
+    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
+    <java.level>7</java.level>
+    <!-- Jenkins Test Harness version you use to test the plugin. -->
+    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
+    <jenkins-test-harness.version>1.532.3</jenkins-test-harness.version>
+    <!-- Other properties you may want to use:
+         ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
+         ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
+    -->
+  </properties>
+  <groupId>org.jenkins-ci.plugins</groupId>
+  <artifactId>vagrant</artifactId>
+  <version>1.0.3-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>vagrant</name>
+  <description>Vagrant plugin to execute and manage vagrant commands on remote nodes</description>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Vagrant-plugin</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>ShimiTaNaka</id>
+      <name>Elad Shmitanka</name>
+      <email>elad.shmitanka@gmail.com</email>
+    </developer>
+  </developers>
+
+  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <scm>
+    <connection>scm:git:ssh://github.com/jenkinsci/vagrant-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/vagrant-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/vagrant-plugin</url>
+    <tag>vagrant-1.0.3</tag>
+  </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <compatibleSinceVersion>1.0.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <common.text.version>1.12.0</common.text.version>
     <asm.version>9.7.1</asm.version>
     <gson.version>2.11.0</gson.version>
-    <jackson.version>2.17.2</jackson.version>
+    <jackson.version>2.18.0</jackson.version>
     <maven.version>3.9.9</maven.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <jgit.version>7.0.0.202409031743-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <!-- Version -->
     <openrewrite.bom.version>2.21.0</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>5.42.0</openrewrite.maven.plugin.version>
-    <openrewrite.jenkins.version>0.14.0</openrewrite.jenkins.version>
+    <openrewrite.jenkins.version>0.14.1</openrewrite.jenkins.version>
     <micrometer.version>1.13.5</micrometer.version>
     <slf4j.version>2.0.16</slf4j.version>
     <logback.version>1.5.9</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <spotless.check.skip>false</spotless.check.skip>
 
     <!-- Version -->
-    <openrewrite.bom.version>2.20.0</openrewrite.bom.version>
+    <openrewrite.bom.version>2.21.0</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>5.42.0</openrewrite.maven.plugin.version>
     <openrewrite.jenkins.version>0.14.0</openrewrite.jenkins.version>
     <micrometer.version>1.13.5</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <!-- Version -->
     <openrewrite.bom.version>2.20.0</openrewrite.bom.version>
-    <openrewrite.maven.plugin.version>5.41.0</openrewrite.maven.plugin.version>
+    <openrewrite.maven.plugin.version>5.42.0</openrewrite.maven.plugin.version>
     <openrewrite.jenkins.version>0.14.0</openrewrite.jenkins.version>
     <micrometer.version>1.13.5</micrometer.version>
     <slf4j.version>2.0.16</slf4j.version>
@@ -61,7 +61,7 @@
     <jgit.version>7.0.0.202409031743-r</jgit.version>
     <github-api.version>1.326</github-api.version>
     <commons-compress.version>1.27.1</commons-compress.version>
-    <byte-buddy.version>1.15.3</byte-buddy.version>
+    <byte-buddy.version>1.15.4</byte-buddy.version>
     <wiremock.version>3.9.1</wiremock.version>
     <jte.version>3.1.13</jte.version>
     <snakeyaml.version>2.3</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <!-- Version -->
     <openrewrite.bom.version>2.21.0</openrewrite.bom.version>
-    <openrewrite.maven.plugin.version>5.42.0</openrewrite.maven.plugin.version>
+    <openrewrite.maven.plugin.version>5.42.2</openrewrite.maven.plugin.version>
     <openrewrite.jenkins.version>0.14.1</openrewrite.jenkins.version>
     <micrometer.version>1.13.5</micrometer.version>
     <slf4j.version>2.0.16</slf4j.version>


### PR DESCRIPTION
Fixes #20

Add transformation step for POMs using JDK versions older than 8.

* Add a call to `ensureMinimalBuild` method in `process` method of `PluginModernizer.java` before `plugin.checkoutBranch`.
* Update `ensureMinimalBuild` method in `MavenInvoker.java` to invoke `MINIMAL_BUILD_JAVA_8_RECIPE`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/issues/20?shareId=39cba581-5b0c-40b1-b95c-ed871495e8ea).