### PR TITLE
Fix: Remove comments associated with deleted properties in pom.xml

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -82,6 +82,12 @@ public class PomModifier {
                 if (node.getNodeType() == Node.ELEMENT_NODE) {
                     String nodeName = node.getNodeName();
                     if (nodeName.equals("jenkins-test-harness.version") || nodeName.equals("java.level")) {
+                        // Remove associated comments
+                        Node previousSibling = node.getPreviousSibling();
+                        while (previousSibling != null && previousSibling.getNodeType() == Node.COMMENT_NODE) {
+                            propertiesNode.removeChild(previousSibling);
+                            previousSibling = node.getPreviousSibling();
+                        }
                         propertiesNode.removeChild(node);
                     }
                 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -1,7 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.core.utils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -16,7 +15,6 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -92,7 +90,16 @@ public class PomModifier {
                         int j = i - 1;
                         while (j >= 0) {
                             Node previousNode = childNodes.item(j);
-                            if (previousNode.getNodeType() == Node.COMMENT_NODE || (previousNode.getNodeType() == Node.TEXT_NODE && previousNode.getTextContent().trim().startsWith("<!--")) || previousNode.getTextContent().replaceAll("\\s+", "").isEmpty()) {
+                            if (previousNode.getNodeType() == Node.COMMENT_NODE
+                                    || (previousNode.getNodeType() == Node.TEXT_NODE
+                                            && previousNode
+                                                    .getTextContent()
+                                                    .trim()
+                                                    .startsWith("<!--"))
+                                    || previousNode
+                                            .getTextContent()
+                                            .replaceAll("\\s+", "")
+                                            .isEmpty()) {
                                 nodesToRemove.add(previousNode);
                                 j--;
                             } else {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -63,6 +63,11 @@ public class PomModifierTest {
                         .getLength()
                 == 0);
         logger.info("Offending properties removed successfully");
+
+        // Verify that comments associated with the removed properties are also removed
+        String pomContent = new String(Files.readAllBytes(Paths.get(OUTPUT_POM_PATH)));
+        assertTrue(!pomContent.contains("<!-- Java Level to use. Java 7 required when using core >= 1.612 -->"));
+        assertTrue(!pomContent.contains("<!-- Jenkins Test Harness version you use to test the plugin. -->"));
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * Test class for PomModifier.
+ */
 public class PomModifierTest {
     private static final Logger logger = Logger.getLogger(PomModifierTest.class.getName());
 
@@ -36,6 +39,11 @@ public class PomModifierTest {
         }
     }
 
+    /**
+     * Sets up the test environment by copying the test POM file to a temporary file.
+     *
+     * @throws Exception if an error occurs during setup
+     */
     @BeforeEach
     public void setUp() throws Exception {
         Path tempFile = new File(OUTPUT_POM_PATH).toPath();
@@ -43,6 +51,11 @@ public class PomModifierTest {
         logger.info("Setup completed, copied test POM to temporary file: " + tempFile);
     }
 
+    /**
+     * Tests the removeOffendingProperties method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
     @Test
     public void testRemoveOffendingProperties() throws Exception {
         PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
@@ -77,6 +90,11 @@ public class PomModifierTest {
                 "Comment for jenkins-test-harness.version should be removed");
     }
 
+    /**
+     * Tests the updateParentPom method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
     @Test
     public void testUpdateParentPom() throws Exception {
         PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
@@ -99,6 +117,11 @@ public class PomModifierTest {
                 "4.80", parentElement.getElementsByTagName("version").item(0).getTextContent());
     }
 
+    /**
+     * Tests the updateJenkinsMinimalVersion method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
     @Test
     public void testUpdateJenkinsMinimalVersion() throws Exception {
         PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -1,8 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.core.utils;
 
 import static java.nio.file.Files.createTempFile;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +40,7 @@ public class PomModifierTest {
     public void setUp() throws Exception {
         Path tempFile = new File(OUTPUT_POM_PATH).toPath();
         Files.copy(Path.of(TEST_POM_PATH), tempFile, StandardCopyOption.REPLACE_EXISTING);
-        logger.info("Setup completed, copied test POM to temporary file: " + tempFile.toString());
+        logger.info("Setup completed, copied test POM to temporary file: " + tempFile);
     }
 
     @Test
@@ -57,17 +56,25 @@ public class PomModifierTest {
 
         Element propertiesElement =
                 (Element) doc.getElementsByTagName("properties").item(0);
-        assertTrue(propertiesElement.getElementsByTagName("java.level").getLength() == 0);
-        assertTrue(propertiesElement
+        assertEquals(
+                0,
+                propertiesElement.getElementsByTagName("java.level").getLength(),
+                "java.level property should be removed");
+        assertEquals(
+                0,
+                propertiesElement
                         .getElementsByTagName("jenkins-test-harness.version")
-                        .getLength()
-                == 0);
-        logger.info("Offending properties removed successfully");
+                        .getLength(),
+                "jenkins-test-harness.version property should be removed");
 
         // Verify that comments associated with the removed properties are also removed
         String pomContent = new String(Files.readAllBytes(Paths.get(OUTPUT_POM_PATH)));
-        assertTrue(!pomContent.contains("<!-- Java Level to use. Java 7 required when using core >= 1.612 -->"));
-        assertTrue(!pomContent.contains("<!-- Jenkins Test Harness version you use to test the plugin. -->"));
+        assertFalse(
+                pomContent.contains("Java Level to use. Java 7 required when using core >= 1.612"),
+                "Comment for java.level should be removed");
+        assertFalse(
+                pomContent.contains("Jenkins Test Harness version you use to test the plugin."),
+                "Comment for jenkins-test-harness.version should be removed");
     }
 
     @Test


### PR DESCRIPTION
Fixes #35

Enhance the `removeOffendingProperties` method in `PomModifier.java` to remove comments associated with deleted properties.

* Identify comments directly above the properties `jenkins-test-harness.version` and `java.level` and remove them along with the properties.
* Update unit tests in `PomModifierTest.java` to verify the removal of comments associated with deleted properties.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/issues/35?shareId=21db17f6-3463-49ce-959d-2b666e779310).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for invalid POM file paths.
	- Added a new test for updating the Jenkins minimal version in the POM file.

- **Bug Fixes**
	- Improved clarity in the removal process of offending properties in the POM file.

- **Documentation**
	- Added Javadoc comments to the test class and methods for better clarity.

- **Tests**
	- Updated assertions in tests for better readability and intent.
	- Expanded test coverage with new assertions and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->