### PR TITLE
Sort plugins by installations

### DIFF
--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
@@ -293,4 +293,18 @@ public class MainTest {
         int exitCode = commandLine.execute(args);
         assertNotEquals(CommandLine.ExitCode.OK, exitCode);
     }
+
+    @Test
+    public void testSortPluginsByInstallations() throws IOException {
+        Path pluginFile = tempDir.resolve("plugins.txt");
+        Files.write(pluginFile, List.of("plugin1", "plugin2", "plugin3"));
+        String[] args = {"-f", pluginFile.toString(), "-r", "FetchMetadata", "--sort-by-installations"};
+        commandLine.execute(args);
+        List<Plugin> plugins = main.setup().getPlugins();
+        assertNotNull(plugins);
+        assertEquals(3, plugins.size());
+        assertEquals("plugin3", plugins.get(0).getName());
+        assertEquals("plugin2", plugins.get(1).getName());
+        assertEquals("plugin1", plugins.get(2).getName());
+    }
 }


### PR DESCRIPTION
Fixes #37

Add functionality to sort plugins by the number of installations.

* Add a new command-line option `--sort-by-installations` in `plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java` to enable sorting of plugins by the number of installations.
* Implement a method `sortPluginsByInstallations` in `Main.java` to sort the plugins by the number of installations.
* Update the `run` method in `Main.java` to call the `sortPluginsByInstallations` method if the `--sort-by-installations` option is provided.
* Add a test method `testSortPluginsByInstallations` in `plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java` to verify the sorting functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/issues/37?shareId=66ee238d-01a2-4a24-b22c-00776b7ed184).