### PR TITLE
Docker build bug

### DIFF
--- a/.github/workflows/github-docker-registry-push.yml
+++ b/.github/workflows/github-docker-registry-push.yml
@@ -55,6 +55,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Install the right Maven version
+        uses: s4u/setup-maven-action@v1.15.0
+
       # Build the project with Maven and install dependencies in the Docker context
       - name: Build with Maven and install dependencies in the Docker context
         run: mvn --version && mvn clean install && cp -vraxu ~/.m2 .m2

--- a/.github/workflows/github-docker-registry-push.yml
+++ b/.github/workflows/github-docker-registry-push.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Build the project with Maven and install dependencies in the Docker context
       - name: Build with Maven and install dependencies in the Docker context
-        run: mvn clean install && cp -vraxu ~/.m2 .m2
+        run: mvn --version && mvn clean install && cp -vraxu ~/.m2 .m2
         env:
           MAVEN_CACHE: ${{ env.MAVEN_CACHE_PATH }}
 

--- a/.github/workflows/github-docker-registry-push.yml
+++ b/.github/workflows/github-docker-registry-push.yml
@@ -60,7 +60,7 @@ jobs:
 
       # Build the project with Maven and install dependencies in the Docker context
       - name: Build with Maven and install dependencies in the Docker context
-        run: mvn --version && mvn clean install && cp -vraxu ~/.m2 .m2
+        run: mvn clean install && cp -vraxu ~/.m2 .m2
         env:
           MAVEN_CACHE: ${{ env.MAVEN_CACHE_PATH }}
 

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -190,3 +190,24 @@ tags: ['chore']
 recipeList:
   - org.openrewrite.jenkins.ModernizeJenkinsfile
   - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.AddDependencyCheck
+displayName: Add dependency check
+description: Adds a dependabot GitHub action to the plugin repository
+tags: ['chore']
+recipeList:
+  - org.openrewrite.text.CreateTextFile:
+      fileContents: |
+        version: 2
+        updates:
+        - package-ecosystem: maven
+          directory: /
+          schedule:
+            interval: monthly
+        - package-ecosystem: github-actions
+          directory: /
+          schedule:
+            interval: monthly
+      relativeFileName: .github/dependabot.yml
+      overwriteExisting: false


### PR DESCRIPTION
Should fix https://github.com/jenkinsci/plugin-modernizer-tool/issues/339 .

I don't know if we changed some of our plugins' versions that force us to use maven 3.9.9, or if the GitHub runners were running maven 3.9.9 before, but they are today using maven 3.8.8, which makes the build fail.

We then force to use the latest maven distribution available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow for building and pushing Docker images to include a new step for installing a specific version of Maven.
	- Introduced a new recipe for Jenkins plugin modernization to enhance automated dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->