### PR TITLE
Add test

### DIFF
--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -142,4 +142,28 @@ public class PomModifierTest {
         logger.info("Jenkins version found: " + jenkinsVersion);
         assertEquals("2.462.2", jenkinsVersion);
     }
+
+    /**
+     * Tests the replaceHttpWithHttps method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testReplaceHttpWithHttps() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.replaceHttpWithHttps();
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        NodeList repositoryUrls = doc.getElementsByTagName("url");
+        for (int i = 0; i < repositoryUrls.getLength(); i++) {
+            Node urlNode = repositoryUrls.item(i);
+            String url = urlNode.getTextContent();
+            assertTrue(url.startsWith("https://"), "URL should start with https://");
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <jgit.version>7.0.0.202409031743-r</jgit.version>
     <github-api.version>1.326</github-api.version>
     <commons-compress.version>1.27.1</commons-compress.version>
-    <byte-buddy.version>1.15.4</byte-buddy.version>
+    <byte-buddy.version>1.15.5</byte-buddy.version>
     <wiremock.version>3.9.1</wiremock.version>
     <jte.version>3.1.13</jte.version>
     <snakeyaml.version>2.3</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.124</version>
+    <version>1.125</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Fixes #45

Add a test for the `replaceHttpWithHttps` method in `PomModifierTest.java`.

* Add a new test method `testReplaceHttpWithHttps` to test the `replaceHttpWithHttps` method.
* Initialize `PomModifier` with `OUTPUT_POM_PATH` in the new test method.
* Call `replaceHttpWithHttps` method in the new test method.
* Save the modified POM to `OUTPUT_POM_PATH` in the new test method.
* Parse the modified POM and assert that all `http` URLs are replaced with `https`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/issues/45?shareId=d66ef8a7-e5e8-406b-84ac-cf3e92d525c6).