### PR TITLE
Add self-closing relativePath tag to parent tag in pom.xml

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -36,6 +36,10 @@ public class Plugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(Plugin.class);
 
+    public Logger getLogger() {
+        return Plugin.LOG;
+    }
+
     /**
      * The configuration to use
      */

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -115,13 +115,20 @@ public enum PreconditionError {
                 }
             },
             plugin -> {
-                PomModifier pomModifier = new PomModifier(
-                        plugin.getLocalRepository().resolve("pom.xml").toString());
-                pomModifier.addRelativePath();
-                pomModifier.savePom(
-                        plugin.getLocalRepository().resolve("pom.xml").toString());
-                plugin.withoutErrors();
-                return true;
+                try {
+                    PomModifier pomModifier = new PomModifier(
+                            plugin.getLocalRepository().resolve("pom.xml").toString());
+                    if (!pomModifier.addRelativePath()) {
+                        return false;
+                    }
+                    pomModifier.savePom(
+                            plugin.getLocalRepository().resolve("pom.xml").toString());
+                    plugin.withoutErrors();
+                    return true;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
             },
             "Missing relative path in pom file preventing parent download");
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -119,6 +119,7 @@ public enum PreconditionError {
                     PomModifier pomModifier = new PomModifier(
                             plugin.getLocalRepository().resolve("pom.xml").toString());
                     if (!pomModifier.addRelativePath()) {
+                        plugin.getLogger().warn("Failed to add relative path to POM file");
                         return false;
                     }
                     pomModifier.savePom(
@@ -126,7 +127,7 @@ public enum PreconditionError {
                     plugin.withoutErrors();
                     return true;
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    plugin.getLogger().error("Error while adding relative path: " + e.getMessage());
                     return false;
                 }
             },

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -115,9 +115,13 @@ public enum PreconditionError {
                 }
             },
             plugin -> {
-                // TODO: Implement remediation function (See
-                // https://github.com/jenkinsci/plugin-modernizer-tool/pull/307)
-                return false;
+                PomModifier pomModifier = new PomModifier(
+                        plugin.getLocalRepository().resolve("pom.xml").toString());
+                pomModifier.addRelativePath();
+                pomModifier.savePom(
+                        plugin.getLocalRepository().resolve("pom.xml").toString());
+                plugin.withoutErrors();
+                return true;
             },
             "Missing relative path in pom file preventing parent download");
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -269,6 +269,18 @@ public class PomModifier {
     }
 
     /**
+     * Adds a self-closing <relativePath/> tag to the parent section of the POM file.
+     */
+    public void addRelativePath() {
+        NodeList parentList = document.getElementsByTagName("parent");
+        if (parentList.getLength() > 0) {
+            Node parentNode = parentList.item(0);
+            Element relativePathElement = document.createElement("relativePath");
+            parentNode.appendChild(relativePathElement);
+        }
+    }
+
+    /**
      * Saves the modified POM file to the specified output path.
      *
      * @param outputPath the path to save the POM file

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -271,13 +271,16 @@ public class PomModifier {
     /**
      * Adds a self-closing <relativePath/> tag to the parent section of the POM file.
      */
-    public void addRelativePath() {
+    public boolean addRelativePath() {
+        boolean managedToInsertRelativePath = false;
         NodeList parentList = document.getElementsByTagName("parent");
         if (parentList.getLength() > 0) {
             Node parentNode = parentList.item(0);
             Element relativePathElement = document.createElement("relativePath");
             parentNode.appendChild(relativePathElement);
+            managedToInsertRelativePath = true;
         }
+        return managedToInsertRelativePath;
     }
 
     /**

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -168,4 +168,26 @@ public class PomModifierTest {
             assertTrue(url.startsWith("https://"), "URL should start with https://");
         }
     }
+
+    /**
+     * Tests the addRelativePath method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testAddRelativePath() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.addRelativePath();
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        NodeList relativePathList = doc.getElementsByTagName("relativePath");
+        assertEquals(1, relativePathList.getLength(), "There should be one relativePath element");
+        Node relativePathNode = relativePathList.item(0);
+        assertTrue(relativePathNode.getTextContent().isEmpty(), "The relativePath element should be self-closing");
+    }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -177,7 +177,7 @@ public class PomModifierTest {
     @Test
     public void testAddRelativePath() throws Exception {
         PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
-        pomModifier.addRelativePath();
+        assertTrue(pomModifier.addRelativePath());
         pomModifier.savePom(OUTPUT_POM_PATH);
 
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -187,7 +187,10 @@ public class PomModifierTest {
 
         NodeList relativePathList = doc.getElementsByTagName("relativePath");
         assertEquals(1, relativePathList.getLength(), "There should be one relativePath element");
-        Node relativePathNode = relativePathList.item(0);
+        Element parentElement = (Element) doc.getElementsByTagName("parent").item(0);
+        Node relativePathNode =
+                parentElement.getElementsByTagName("relativePath").item(0);
+        assertNotNull(relativePathNode, "The relativePath element should be a child of the parent element");
         assertTrue(relativePathNode.getTextContent().isEmpty(), "The relativePath element should be self-closing");
     }
 }

--- a/plugin-modernizer-core/src/test/resources/test-pom.xml
+++ b/plugin-modernizer-core/src/test/resources/test-pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>1.554.1</version>
-    <relativePath />
   </parent>
 
   <properties>


### PR DESCRIPTION
Fixes #49

Add a method to add a self-closing `<relativePath/>` tag to the `pom.xml`.

* **PomModifier.java**
  - Add a method `addRelativePath` to add a self-closing `<relativePath/>` tag to the `pom.xml`.
  - Ensure the method modifies the DOM and saves the modified file.

* **PreconditionError.java**
  - Replace the TODO comment with a call to the `addRelativePath` method.

* **PomModifierTest.java**
  - Add a test method `testAddRelativePath` to verify the addition of a self-closing `<relativePath/>` tag.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/issues/49?shareId=920d7626-d45d-4ab2-aa05-1b15e78d4078).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for missing relative paths in plugin configuration.
	- Introduced a method to automatically add a `<relativePath/>` tag to POM files.

- **Bug Fixes**
	- Improved functionality for error remediation related to missing relative paths.

- **Tests**
	- Added a test to validate the new functionality for adding a relative path in POM files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->