### PR TITLE
Add XML declaration to Jelly files

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipe/AddJellyXmlDeclaration.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipe/AddJellyXmlDeclaration.java
@@ -1,0 +1,43 @@
+package io.jenkins.tools.pluginmodernizer.core.recipe;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.PlainTextVisitor;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextParser;
+import org.openrewrite.text.PlainTextVisitor;
+import org.openrewrite.text.PlainText;
+
+import java.util.List;
+
+public class AddJellyXmlDeclaration extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Add XML declaration to Jelly files";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Ensure the XML declaration `<?jelly escape-by-default='true'?>` is present in all `.jelly` files.";
+    }
+
+    @Override
+    protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
+        return new PlainTextVisitor<ExecutionContext>() {
+            @Override
+            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+                if (text.getSourcePath().toString().endsWith(".jelly")) {
+                    String content = text.getText();
+                    if (!content.startsWith("<?jelly escape-by-default='true'?>")) {
+                        content = "<?jelly escape-by-default='true'?>\n" + content;
+                        return text.withText(content);
+                    }
+                }
+                return text;
+            }
+        }.visit(before, ctx);
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -201,3 +201,11 @@ recipeList:
             interval: monthly
       relativeFileName: .github/dependabot.yml
       overwriteExisting: false
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.AddJellyXmlDeclaration
+displayName: Add XML declaration to Jelly files
+description: Ensure the XML declaration `<?jelly escape-by-default='true'?>` is present in all `.jelly` files.
+tags: ['chore']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.core.recipe.AddJellyXmlDeclaration

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipe/AddJellyXmlDeclarationTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipe/AddJellyXmlDeclarationTest.java
@@ -1,0 +1,70 @@
+package io.jenkins.tools.pluginmodernizer.core.recipe;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.RewriteTestRunner;
+import org.openrewrite.test.SourceSpec;
+
+import java.nio.file.Paths;
+
+import static org.openrewrite.test.SourceSpecs.text;
+
+public class AddJellyXmlDeclarationTest implements RewriteTest {
+
+    @Override
+    public Recipe getRecipe() {
+        return new AddJellyXmlDeclaration();
+    }
+
+    @Test
+    void addXmlDeclarationToJellyFile() {
+        rewriteRun(
+                spec -> spec.recipe(new AddJellyXmlDeclaration())
+                        .parser(new PlainTextParser())
+                        .expectedCyclesThatMakeChanges(1)
+                        .cycles(1),
+                text(
+                        """
+                        <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+                            <st:contentType value="text/html"/>
+                            <h1>Hello, World!</h1>
+                        </j:jelly>
+                        """,
+                        """
+                        <?jelly escape-by-default='true'?>
+                        <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+                            <st:contentType value="text/html"/>
+                            <h1>Hello, World!</h1>
+                        </j:jelly>
+                        """
+                )
+        );
+    }
+
+    @Test
+    void doNotAddXmlDeclarationIfAlreadyPresent() {
+        rewriteRun(
+                spec -> spec.recipe(new AddJellyXmlDeclaration())
+                        .parser(new PlainTextParser())
+                        .expectedCyclesThatMakeChanges(1)
+                        .cycles(1),
+                text(
+                        """
+                        <?jelly escape-by-default='true'?>
+                        <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+                            <st:contentType value="text/html"/>
+                            <h1>Hello, World!</h1>
+                        </j:jelly>
+                        """,
+                        """
+                        <?jelly escape-by-default='true'?>
+                        <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+                            <st:contentType value="text/html"/>
+                            <h1>Hello, World!</h1>
+                        </j:jelly>
+                        """
+                )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #51

Add a new recipe to ensure the XML declaration is present in all Jelly files.

* Add `AddJellyXmlDeclaration` recipe to `plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml`.
* Create `AddJellyXmlDeclaration` class in `plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipe/AddJellyXmlDeclaration.java`.
* Implement logic to add XML declaration to existing `.jelly` files using `PlainTextVisitor`.
* Create `AddJellyXmlDeclarationTest` class in `plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipe/AddJellyXmlDeclarationTest.java`.
* Write unit tests to verify the `AddJellyXmlDeclaration` recipe.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/issues/51?shareId=ed5b702e-85fc-4947-80e3-6ec0a3bf9ca5).