### PR TITLE
Fix Dockerfile to use pre-built jar file

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -125,6 +125,14 @@ jobs:
             out/jreleaser/trace.log
             out/jreleaser/output.properties
 
+      - name: Upload built jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-jar
+          path: |
+            plugin-modernizer-cli/target/jenkins-plugin-modernizer-${{ steps.extract-version.outputs.version }}.jar
+            plugin-modernizer-core/target/plugin-modernizer-core-${{ steps.extract-version.outputs.version }}.jar
+
   docker:
     runs-on: ubuntu-latest
     needs: [release]
@@ -148,6 +156,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Download built jar
+        uses: actions/download-artifact@v4
+        with:
+          name: built-jar
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -186,3 +199,4 @@ jobs:
           sbom: true
           build-args: |
             MAVEN_CACHE=.m2
+            VERSION=${{ needs.release.outputs.version }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -129,6 +129,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: built-jar
+          retention-days: 1
           path: |
             plugin-modernizer-cli/target/jenkins-plugin-modernizer-${{ steps.extract-version.outputs.version }}.jar
             plugin-modernizer-core/target/plugin-modernizer-core-${{ steps.extract-version.outputs.version }}.jar

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -162,6 +162,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-jar
+          path: .  # Explicitly set to root to match Dockerfile COPY paths
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Define the VERSION argument with a default value
 ARG VERSION=999999-SNAPSHOT
 
-# Second stage: Create the final image using Maven and Eclipse Temurin JDK 21
+# Create the image using Maven and Eclipse Temurin JDK 21
 FROM maven:3.9.9-eclipse-temurin-21-jammy AS result-image
 
 LABEL org.opencontainers.image.description="Using OpenRewrite Recipes for Plugin Modernization or Automation Plugin Build Metadata Updates"
@@ -38,6 +38,7 @@ ENV VERSION=${VERSION}
 # Copy the built JAR files from the downloaded artifacts to the final image
 # Fail fast if jars are missing
 COPY --chmod=755 plugin-modernizer-cli/target/jenkins-plugin-modernizer-${VERSION}.jar /jenkins-plugin-modernizer.jar
+COPY --chmod=755 plugin-modernizer-core/target/plugin-modernizer-core-${VERSION}.jar /jenkins-plugin-modernizer-core.jar
 
 # Install the core dependency using the Maven install plugin
 RUN mvn org.apache.maven.plugins:maven-install-plugin:${MVN_INSTALL_PLUGIN_VERSION}:install-file \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,9 @@ ARG VERSION
 ENV VERSION=${VERSION}
 
 # Copy the built JAR files from the downloaded artifacts to the final image
-COPY plugin-modernizer-cli/target/jenkins-plugin-modernizer-${VERSION}.jar /jenkins-plugin-modernizer.jar
-COPY plugin-modernizer-core/target/plugin-modernizer-core-${VERSION}.jar /jenkins-plugin-modernizer-core.jar
+# Fail fast if jars are missing
+COPY --chmod=755 plugin-modernizer-cli/target/jenkins-plugin-modernizer-${VERSION}.jar /jenkins-plugin-modernizer.jar
+COPY --chmod=755 plugin-modernizer-core/target/plugin-modernizer-core-${VERSION}.jar /jenkins-plugin-modernizer-core.jar
 
 # Install the core dependency using the Maven install plugin
 RUN mvn org.apache.maven.plugins:maven-install-plugin:${MVN_INSTALL_PLUGIN_VERSION}:install-file \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ ENV VERSION=${VERSION}
 # Copy the built JAR files from the downloaded artifacts to the final image
 # Fail fast if jars are missing
 COPY --chmod=755 plugin-modernizer-cli/target/jenkins-plugin-modernizer-${VERSION}.jar /jenkins-plugin-modernizer.jar
-COPY --chmod=755 plugin-modernizer-core/target/plugin-modernizer-core-${VERSION}.jar /jenkins-plugin-modernizer-core.jar
 
 # Install the core dependency using the Maven install plugin
 RUN mvn org.apache.maven.plugins:maven-install-plugin:${MVN_INSTALL_PLUGIN_VERSION}:install-file \


### PR DESCRIPTION
Fixes #67

Update Dockerfile and GitHub Actions workflow to ensure correct version during build process.

* **Dockerfile**:
  - Remove the first build stage.
  - Define the `VERSION` argument and set the `VERSION` environment variable.
  - Update the `COPY` commands to use the pre-built jar files from the downloaded artifacts.

* **.github/workflows/cd.yaml**:
  - Add `actions/upload-artifact` action to upload the built jar as an artifact in the `release` job.
  - Add `actions/download-artifact` action to download the previously uploaded jar file in the `docker` job.
  - Update the `Build and push Docker image` step to pass the `VERSION` environment variable as a build argument.
  - Update the `Extract version` step to include the `-Dset.changelist` parameter when evaluating the project version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/pull/68?shareId=ad2f0ab6-a573-4217-8b2f-adad864f8641).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI/CD Workflow Updates**
	- Enhanced GitHub Actions workflow to support artifact management.
	- Added steps to upload and download built JAR files during release and Docker build processes.
	- Improved Docker image versioning by passing version as a build argument.

- **Dockerfile Modifications**
	- Simplified build process by removing the initial build stage.
	- Directly referencing pre-built JAR files in Docker image creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->