### PR TITLE
Implement a way to customize the pull request body

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -64,7 +64,9 @@ public class TemplateUtils {
      */
     public static String renderPullRequestTitle(Plugin plugin, Recipe recipe) {
         if (hasTitleTemplate(recipe)) {
-            return renderTemplate("pr-title-%s.jte".formatted(getTemplateNameForRecipe("pr-title", recipe)), Map.of("plugin", plugin, "recipe", recipe));
+            return renderTemplate(
+                    "pr-title-%s.jte".formatted(getTemplateNameForRecipe("pr-title", recipe)),
+                    Map.of("plugin", plugin, "recipe", recipe));
         }
         return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipe", recipe));
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -24,22 +24,29 @@ public class TemplateUtils {
      */
     private TemplateUtils() {}
 
+    private static String getTemplateNameForRecipe(String prefix, Recipe recipe) {
+        String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
+        return "%s-%s.jte".formatted(prefix, shortName);
+    }
+
     /**
      * Render the pull request body
+     *
      * @param plugin Plugin to modernize
      * @param recipe Recipe to apply
      * @return The rendered pull request body
      */
     public static String renderPullRequestBody(Plugin plugin, Recipe recipe) {
         if (hasBodyTemplate(recipe)) {
-            String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
-            return renderTemplate("pr-body-%s.jte".formatted(shortName), Map.of("plugin", plugin, "recipe", recipe));
+            return renderTemplate(
+                    getTemplateNameForRecipe("pr-body", recipe), Map.of("plugin", plugin, "recipe", recipe));
         }
         return renderTemplate("pr-body.jte", Map.of("plugin", plugin, "recipe", recipe));
     }
 
     /**
      * Render the commit message
+     *
      * @param plugin Plugin to modernize
      * @param recipe Recipe to apply
      * @return The rendered commit message
@@ -50,6 +57,7 @@ public class TemplateUtils {
 
     /**
      * Render the pull request title
+     *
      * @param plugin Plugin to modernize
      * @param recipe Recipe to apply
      * @return The rendered pull request title
@@ -64,8 +72,9 @@ public class TemplateUtils {
 
     /**
      * Render a generic template
+     *
      * @param templateName Name of the template
-     * @param params Parameters to pass to the template
+     * @param params       Parameters to pass to the template
      * @return The rendered template
      */
     private static String renderTemplate(String templateName, Map<String, Object> params) {
@@ -82,6 +91,7 @@ public class TemplateUtils {
 
     /**
      * Check if a title template exists for one recipe
+     *
      * @param recipe The recipe to check
      * @return True if a title template exists
      */
@@ -93,12 +103,12 @@ public class TemplateUtils {
 
     /**
      * Check if a body template exists for one recipe
+     *
      * @param recipe The recipe to check
      * @return True if a body template exists
      */
     private static boolean hasBodyTemplate(Recipe recipe) {
-        String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
         TemplateEngine templateEngine = TemplateEngine.createPrecompiled(ContentType.Html);
-        return templateEngine.hasTemplate("pr-body-%s.jte".formatted(shortName));
+        return templateEngine.hasTemplate(getTemplateNameForRecipe("pr-body", recipe));
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -64,8 +64,7 @@ public class TemplateUtils {
      */
     public static String renderPullRequestTitle(Plugin plugin, Recipe recipe) {
         if (hasTitleTemplate(recipe)) {
-            String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
-            return renderTemplate("pr-title-%s.jte".formatted(shortName), Map.of("plugin", plugin, "recipe", recipe));
+            return renderTemplate("pr-title-%s.jte".formatted(getTemplateNameForRecipe("pr-title", recipe)), Map.of("plugin", plugin, "recipe", recipe));
         }
         return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipe", recipe));
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -65,7 +65,7 @@ public class TemplateUtils {
     public static String renderPullRequestTitle(Plugin plugin, Recipe recipe) {
         if (hasTitleTemplate(recipe)) {
             String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
-            return renderTemplate("pr-title-%s.jte".formatted(getTemplateNameForRecipe("pr-title", recipe)), Map.of("plugin", plugin, "recipe", recipe));
+            return renderTemplate("pr-title-%s.jte".formatted(shortName), Map.of("plugin", plugin, "recipe", recipe));
         }
         return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipe", recipe));
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -64,9 +64,8 @@ public class TemplateUtils {
      */
     public static String renderPullRequestTitle(Plugin plugin, Recipe recipe) {
         if (hasTitleTemplate(recipe)) {
-            return renderTemplate(
-                    "pr-title-%s.jte".formatted(getTemplateNameForRecipe("pr-title", recipe)),
-                    Map.of("plugin", plugin, "recipe", recipe));
+            String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
+            return renderTemplate("pr-title-%s.jte".formatted(getTemplateNameForRecipe("pr-title", recipe)), Map.of("plugin", plugin, "recipe", recipe));
         }
         return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipe", recipe));
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -64,8 +64,8 @@ public class TemplateUtils {
      */
     public static String renderPullRequestTitle(Plugin plugin, Recipe recipe) {
         if (hasTitleTemplate(recipe)) {
-            String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
-            return renderTemplate("pr-title-%s.jte".formatted(shortName), Map.of("plugin", plugin, "recipe", recipe));
+            return renderTemplate(
+                    getTemplateNameForRecipe("pr-title", recipe), Map.of("plugin", plugin, "recipe", recipe));
         }
         return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipe", recipe));
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -31,6 +31,10 @@ public class TemplateUtils {
      * @return The rendered pull request body
      */
     public static String renderPullRequestBody(Plugin plugin, Recipe recipe) {
+        if (hasBodyTemplate(recipe)) {
+            String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
+            return renderTemplate("pr-body-%s.jte".formatted(shortName), Map.of("plugin", plugin, "recipe", recipe));
+        }
         return renderTemplate("pr-body.jte", Map.of("plugin", plugin, "recipe", recipe));
     }
 
@@ -85,5 +89,16 @@ public class TemplateUtils {
         String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
         TemplateEngine templateEngine = TemplateEngine.createPrecompiled(ContentType.Html);
         return templateEngine.hasTemplate("pr-title-%s.jte".formatted(shortName));
+    }
+
+    /**
+     * Check if a body template exists for one recipe
+     * @param recipe The recipe to check
+     * @return True if a body template exists
+     */
+    private static boolean hasBodyTemplate(Recipe recipe) {
+        String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
+        TemplateEngine templateEngine = TemplateEngine.createPrecompiled(ContentType.Html);
+        return templateEngine.hasTemplate("pr-body-%s.jte".formatted(shortName));
     }
 }

--- a/plugin-modernizer-core/src/main/jte/pr-body-SetupJenkinsfile.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-SetupJenkinsfile.jte
@@ -5,7 +5,7 @@
 Hello `${plugin.getName()}` developers! :wave:
 
 This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
-<details>
+<details aria-label="Recipe details for ${recipe.getDisplayName()}">
     <summary>${recipe.getDisplayName()}</summary>
     <p><em>${recipe.getName()}</em></p>
     <blockquote>${recipe.getDescription()}</blockquote>

--- a/plugin-modernizer-core/src/main/jte/pr-body-SetupJenkinsfile.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-SetupJenkinsfile.jte
@@ -1,0 +1,16 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Hello `${plugin.getName()}` developers!
+
+This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
+<details>
+    <summary>${recipe.getDisplayName()}</summary>
+    <p><em>${recipe.getName()}</em></p>
+    <blockquote>${recipe.getDescription()}</blockquote>
+</details>
+
+### Why is this important?
+
+The `SetupJenkinsfile` recipe is crucial for ensuring that your Jenkins plugin is built and tested using the Jenkins infrastructure. By adding a Jenkinsfile, you enable continuous integration and continuous delivery (CI/CD) for your plugin, which helps in maintaining the quality and reliability of the plugin. It also ensures that your plugin is tested against the latest Jenkins core and other plugins, providing early feedback on any potential issues.

--- a/plugin-modernizer-core/src/main/jte/pr-body-SetupJenkinsfile.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-SetupJenkinsfile.jte
@@ -2,7 +2,7 @@
 @import io.jenkins.tools.pluginmodernizer.core.model.Recipe
 @param Plugin plugin
 @param Recipe recipe
-Hello `${plugin.getName()}` developers!
+Hello `${plugin.getName()}` developers! :wave:
 
 This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
 <details>
@@ -11,6 +11,15 @@ This is an automated pull request created by the [Jenkins Plugin Modernizer](htt
     <blockquote>${recipe.getDescription()}</blockquote>
 </details>
 
-### Why is this important?
+## Why is this important?
 
-The `SetupJenkinsfile` recipe is crucial for ensuring that your Jenkins plugin is built and tested using the Jenkins infrastructure. By adding a Jenkinsfile, you enable continuous integration and continuous delivery (CI/CD) for your plugin, which helps in maintaining the quality and reliability of the plugin. It also ensures that your plugin is tested against the latest Jenkins core and other plugins, providing early feedback on any potential issues.
+Starting with the Jenkins 2.463 weekly release, Jenkins now requires Java 17 or newer.
+The first Long-Term Support (LTS) release requiring Java 17 or newer (version 2.479.x) was released at the end of October 2024.
+
+The Jenkins core team strongly recommends that all users adopt either Java 17 or Java 21.
+The adoption of Java 17 has almost surpassed that of Java 11, and the usage of Java 21 is rapidly increasing.
+
+There will come a time when we no longer support plugins built with JDK 8 or 11.
+
+While this PR does not automatically make your plugin compatible with Java 17 or 21, it represents the first step towards a new era. Your plugin will be built and tested within the Jenkins infrastructure using Java 17 and 21.
+After this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21.

--- a/plugin-modernizer-core/src/main/jte/pr-title-SetupJenkinsfile.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-SetupJenkinsfile.jte
@@ -1,0 +1,5 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+feat(ci): Builds on the Jenkins Infrastructure


### PR DESCRIPTION
Fixes #75

Add support for customizing the pull request body using `jte` template files.

* Add a new method `hasBodyTemplate` in `TemplateUtils.java` to check for specific `jte` templates for the pull request body.
* Update the `renderPullRequestBody` method in `TemplateUtils.java` to use specific `jte` templates if available.
* Create a new `jte` template `pr-body-SetupJenkinsfile.jte` for customizing the pull request body for the `SetupJenkinsfile` recipe, including a detailed explanation of why this recipe is important.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/pull/76?shareId=12e04d78-4ec9-4f88-89fa-4b28462b2205).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new method to check for body templates in the plugin modernization process
	- Introduced a specialized template for Jenkins plugin modernization pull requests

- **Documentation**
	- Enhanced pull request body template with detailed guidance on Java version requirements and modernization steps

The changes improve the Jenkins Plugin Modernizer tool's template rendering and provide clearer instructions for plugin maintainers about Java version transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->