### PR TITLE
Add updatecli manifest for UpdateBomTest.java

### DIFF
--- a/updatecli/updatecli.d/update-bom-test.yaml
+++ b/updatecli/updatecli.d/update-bom-test.yaml
@@ -1,0 +1,46 @@
+name: Update io.jenkins.tools.bom:bom-2.452.x version in UpdateBomTest.java
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestBomVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "bom"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateBomVersionInTest:
+    name: "Update io.jenkins.tools.bom:bom-2.452.x version in UpdateBomTest.java"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBomTest.java
+      matchPattern: "(?m)<version>.*</version>"
+      replacePattern: '<version>{{ source "latestBomVersion" }}</version>'
+    sourceid: latestBomVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update io.jenkins.tools.bom:bom-2.452.x version to {{ source "latestBomVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli


### PR DESCRIPTION
Fixes #89

Add updatecli manifest to automate version update for `io.jenkins.tools.bombom-2.452.x` in `UpdateBomTest.java`.

* Create `updatecli/updatecli.d/update-bom-test.yaml` to define the updatecli manifest.
* Define `name`, `scms`, `sources`, `targets`, and `actions` sections in the YAML file.
* Use the `file` type in the `targets` section to update the version in `plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBomTest.java`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/pull/90?shareId=e36b3a12-830b-4bab-a4fa-29bfe43efa71).