### PR TITLE
Log plugin modernization failures in plugin file format

### DIFF
--- a/plugin-modernizer-cli/src/main/resources/logback.xml
+++ b/plugin-modernizer-cli/src/main/resources/logback.xml
@@ -33,9 +33,23 @@
             </appender>
         </sift>
     </appender>
+    <appender name="FAILURE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <file>${user.home}/.cache/jenkins-plugin-modernizer-cli/modernization-failures-${date:yyyyMMdd-HHmmss}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${user.home}/.cache/jenkins-plugin-modernizer-cli/modernization-failures-%d{yyyyMMdd-HHmmss}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+    </appender>
     <root>
         <appender-ref ref="CONSOLE" />
         <appender-ref ref="SIFT" />
+        <appender-ref ref="FAILURE" />
     </root>
     <logger name="jdk.httpclient" level="INFO" />
     <logger name="jdk.internal.httpclient.debug" level="WARN" />

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -343,6 +343,7 @@ public class Plugin {
             LOG.error(message);
         }
         errors.add(new PluginProcessingException(message, e, this));
+        logFailure();
     }
 
     /**
@@ -352,6 +353,34 @@ public class Plugin {
     public void addError(String message) {
         LOG.error(message);
         errors.add(new PluginProcessingException(message, this));
+        logFailure();
+    }
+
+    /**
+     * Log the failure in the separate log file
+     */
+    private void logFailure() {
+        Path failureLogPath = Path.of(System.getProperty("user.home"), ".cache", "jenkins-plugin-modernizer-cli", "modernization-failures-" + java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")) + ".log");
+        ensureLogDirectoryExists(failureLogPath);
+        try {
+            Files.writeString(failureLogPath, name + "\n", java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            LOG.error("Failed to write to failure log file: " + failureLogPath, e);
+        }
+    }
+
+    /**
+     * Log network-related failures in a separate log file
+     * @param message The message
+     */
+    public void logNetworkFailure(String message) {
+        Path networkFailureLogPath = Path.of(System.getProperty("user.home"), ".cache", "jenkins-plugin-modernizer-cli", "network-failures-" + java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")) + ".log");
+        ensureLogDirectoryExists(networkFailureLogPath);
+        try {
+            Files.writeString(networkFailureLogPath, name + ": " + message + "\n", java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            LOG.error("Failed to write to network failure log file: " + networkFailureLogPath, e);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #98

Add separate logging for plugin modernization failures.

* Add a new appender in `plugin-modernizer-cli/src/main/resources/logback.xml` to log failures separately in `modernization-failures-YYYYMMDD-HHMMSS.log`.
* Update `plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java` to log failures in the new log file.
* Add a method in `plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java` to log network-related failures in `network-failures-YYYYMMDD-HHMMSS.log`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/plugin-modernizer-tool/pull/99?shareId=dbd2df87-adb9-4539-949b-32e991a9eb27).